### PR TITLE
Use bootstrap icons instead of fontawesome

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,6 +5,7 @@ website:
   title: "EpiForecasts"
   site-url: https://epiforecasts.io
   repo-url: https://github.com/epiforecasts/epiforecasts.github.io
+  body-header: '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/academicons/1.7.0/css/academicons.min.css" integrity="sha512-GGGNUPDhnG8LEAEDsjqYIQns+Gu8RBs4j5XGlxl7UfRaZBhCCm5jenJkeJL8uPuOXGqgl8/H1gjlWQDRjd3cUQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />'
   body-footer: '<script data-goatcounter="https://epiforecasts.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>'
   twitter-card: 
     site: "@epiforecasts"

--- a/_team_member.Rmd
+++ b/_team_member.Rmd
@@ -25,15 +25,11 @@ if ("{{webpage}}" != "") {
 }
 
 if ("{{github}}" != "") {
-  title <- paste(title, icon_link("fab fa-github", url = "https://github.com/{{github}}"))
+  title <- paste(title, icon_link("bi bi-github", url = "https://github.com/{{github}}"))
 }
 
 if ("{{twitter}}" != "") {
-  title <- paste(title, icon_link("fab fa-twitter", url = "https://twitter.com/{{twitter}}"))
-}
-
-if ("{{orcid}}" != "") {
-  title <- paste(title, icon_link("fab fa-orcid", url = "https://orcid.org/{{orcid}}"))
+  title <- paste(title, icon_link("bi bi-twitter", url = "https://twitter.com/{{twitter}}"))
 }
 ```
 

--- a/_team_member.Rmd
+++ b/_team_member.Rmd
@@ -31,6 +31,10 @@ if ("{{github}}" != "") {
 if ("{{twitter}}" != "") {
   title <- paste(title, icon_link("bi bi-twitter", url = "https://twitter.com/{{twitter}}"))
 }
+
+if ("{{orcid}}" != "") {
+  title <- paste(title, icon_link("ai ai-orcid", url = "https://orcid.org/{{orcid}}"))
+}
 ```
 
 ### `r title`

--- a/people.qmd
+++ b/people.qmd
@@ -33,6 +33,7 @@ current_team %>%
       webpage = e[["webpage"]],
       github = e[["github"]],
       twitter = e[["twitter"]],
+      orcid = e[["orcid"]],
       description = e[["description"]]
     )
   }) %>%

--- a/people.qmd
+++ b/people.qmd
@@ -1,5 +1,6 @@
 ---
 title: "People"
+link-external-icon: false
 ---
 
 ```{r setup, include=FALSE}
@@ -32,7 +33,6 @@ current_team %>%
       webpage = e[["webpage"]],
       github = e[["github"]],
       twitter = e[["twitter"]],
-      orcid = e[["orcid"]],
       description = e[["description"]]
     )
   }) %>%


### PR DESCRIPTION
This is the best solution I could find. Unfortunately, it removes the link to the orcid profile.

For context, it looks like quarto doesn't include fontawesome out-of-the-box. You can add it via an extension (https://github.com/quarto-ext/fontawesome) but I can't get it to work. I suspect it's because we're using the icons in a `.Rmd` file and not a `.qmd` file so the shortcodes don't work :shrug:

Fix #38