### PR TITLE
allow last digit to be an X in orcid schema

### DIFF
--- a/_data/team/_schema.yml
+++ b/_data/team/_schema.yml
@@ -20,7 +20,7 @@ properties:
   orcid:
     description: Your ORCiD
     type: string
-    pattern: ^\d{4}\-\d{4}\-\d{4}-\d{4}$
+    pattern: ^\d{4}-\d{4}-\d{4}-\d{3}(X|\d)$
   current-member:
     description: A boolean saying whether you're currently a team member or not.
     type: boolean


### PR DESCRIPTION
https://support.orcid.org/hc/en-us/articles/360053289173-Why-does-my-ORCID-iD-have-an-X-

"ORCID iD's that end with an X are valid and correct."