### PR TITLE
Use sentence case in stan documentation blogpost title

### DIFF
--- a/posts/2025-03-19-stan-doc-guide/index.qmd
+++ b/posts/2025-03-19-stan-doc-guide/index.qmd
@@ -1,6 +1,6 @@
 ---
-title: "Guide To Documenting Stan Functions"
-subtitle: "The example of EpiNow2"
+title: "How we document stan functions"
+subtitle: "An example with EpiNow2"
 author:
   - name: James Mba Azam
     orcid_id: 0000-0001-5782-7330


### PR DESCRIPTION
This PR is to align the case of the title with the existing blogposts. I also make a slight change in the title.